### PR TITLE
feat: Upload & xử lý trong RAM, không lưu mặc định

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+.DS_Store
+.venv/
+__pycache__/
+.ipynb_checkpoints/
+.streamlit/secrets.toml
+
+# Không theo dõi file người dùng upload
+data/uploads/
+uploads/

--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,5 @@
+[client]
+toolbarMode = "viewer"
+
+[theme]
+base = "light"

--- a/modules/io_excel.py
+++ b/modules/io_excel.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+import io, os
+import pandas as pd
+from typing import Dict, Iterable, Tuple, List
+
+def read_any(uploaded_file) -> pd.DataFrame:
+    name = uploaded_file.name.lower()
+    if name.endswith(".csv"):
+        return pd.read_csv(uploaded_file)
+    elif name.endswith(".xlsx"):
+        return pd.read_excel(uploaded_file)
+    else:
+        raise ValueError("Chỉ hỗ trợ .xlsx hoặc .csv")
+
+def to_excel_bytes(sheets: Dict[str, pd.DataFrame]) -> bytes:
+    buf = io.BytesIO()
+    with pd.ExcelWriter(buf, engine="xlsxwriter") as w:
+        for sheet, df in sheets.items():
+            df.to_excel(w, index=False, sheet_name=(sheet or "Sheet1")[:31])
+    return buf.getvalue()
+
+def validate_columns(df: pd.DataFrame, required: Iterable[str]) -> Tuple[bool, List[str]]:
+    missing = [c for c in required if c not in df.columns]
+    return (len(missing) == 0, missing)
+
+def ensure_dir(path: str) -> None:
+    os.makedirs(path, exist_ok=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
-streamlit>=1.32.0
-pandas>=2.0.0
-openpyxl>=3.1.2
-xlrd>=2.0.1
-xlsxwriter>=3.1.9
-Pillow>=9.0.0
+streamlit==1.36.0
+pandas==2.2.2
+openpyxl==3.1.5
+xlsxwriter==3.2.0
+numpy==1.26.4


### PR DESCRIPTION
- Thêm trang "Upload & Xử lý dữ liệu (không lưu)" trong thư mục pages/
- Module io_excel: đọc/xuất Excel hoàn toàn trong RAM
- Bỏ hẳn data/raw, thay bằng data/uploads (chỉ lưu khi bật toggle)
- Thêm .gitignore, .streamlit/config.toml
- Pin requirements.txt với version ổn định
